### PR TITLE
fix: invalid url when making request to oidc

### DIFF
--- a/k8s/src/main/java/com/netcracker/cloud/security/core/utils/k8s/impl/KubernetesOidcRestClient.java
+++ b/k8s/src/main/java/com/netcracker/cloud/security/core/utils/k8s/impl/KubernetesOidcRestClient.java
@@ -38,7 +38,7 @@ public class KubernetesOidcRestClient {
     }
 
     public String getOidcConfiguration(String issuer) {
-        var url = issuer + "/.well-known/openid-configuration";
+        var url = StringUtils.stripEnd(issuer, "/") + "/.well-known/openid-configuration";
         log.info("Request OIDC configuration for {}", url);
         try {
             return objectMapper.readValue(doRequest(url), OidcConfigResponse.class).getJwksUri();

--- a/k8s/src/test/java/com/netcracker/cloud/security/core/utils/k8s/impl/KubernetesOidcRestClientTest.java
+++ b/k8s/src/test/java/com/netcracker/cloud/security/core/utils/k8s/impl/KubernetesOidcRestClientTest.java
@@ -27,7 +27,7 @@ class KubernetesOidcRestClientTest {
 
 
     @Test
-    void getOidcConfiguration() throws IOException {
+    void getOidcConfiguration() throws Exception {
         var mockOidcConfig = "{\"issuer\":\"https://kubernetes.default.svc.cluster.local\","
                 + "\"jwks_uri\":\"https://192.168.49.2:8443/openid/v1/jwks\","
                 + "\"response_types_supported\":[\"id_token\"],"
@@ -44,9 +44,11 @@ class KubernetesOidcRestClientTest {
             var baseUrl = server.url("").toString();
             var actual = restClient.getOidcConfiguration(baseUrl);
             Assertions.assertEquals("https://192.168.49.2:8443/openid/v1/jwks", actual);
+            Assertions.assertEquals("/.well-known/openid-configuration", server.takeRequest().getPath());
 
             actual = restClient.getOidcConfiguration(baseUrl+"/");
             Assertions.assertEquals("https://192.168.49.2:8443/openid/v1/jwks", actual);
+            Assertions.assertEquals("/.well-known/openid-configuration", server.takeRequest().getPath());
         }
     }
 

--- a/k8s/src/test/java/com/netcracker/cloud/security/core/utils/k8s/impl/KubernetesOidcRestClientTest.java
+++ b/k8s/src/test/java/com/netcracker/cloud/security/core/utils/k8s/impl/KubernetesOidcRestClientTest.java
@@ -38,10 +38,14 @@ class KubernetesOidcRestClientTest {
             MockResponse response = new MockResponse();
             response.setBody(mockOidcConfig);
             server.enqueue(response);
+            server.enqueue(response);
             server.start();
 
             var baseUrl = server.url("").toString();
             var actual = restClient.getOidcConfiguration(baseUrl);
+            Assertions.assertEquals("https://192.168.49.2:8443/openid/v1/jwks", actual);
+
+            actual = restClient.getOidcConfiguration(baseUrl+"/");
             Assertions.assertEquals("https://192.168.49.2:8443/openid/v1/jwks", actual);
         }
     }


### PR DESCRIPTION
when constructing request for oidc configuration "var url = issuer + "/.well-known/openid-configuration";" if issuer has trailing '/' url will contain '//'. fixed by using StringUtils.stripEnd.